### PR TITLE
make MillisDuration compatble with `metricator`'s AggregateMetrics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monotonic-time-rs"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2021"
 license = "MIT"
 description = "Monotonic Time"
@@ -8,6 +8,7 @@ repository = "https://github.com/piot/monotonic-time-rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+num-traits = "0.2"
 
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,7 @@ repository = "https://github.com/piot/monotonic-time-rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-num-traits = "0.2"
-
+num-traits = {version="0.2", optional = true}
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3.76", features = ["Performance", "Window"] }
@@ -18,3 +17,7 @@ wasm-bindgen = "0.2.99"
 [dev-dependencies]
 test-log = "^0.2.16"
 log = "0.4.22"
+
+[features]
+metricator-compat = ["dep:num-traits"]
+default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,8 @@ use std::fmt;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 use std::time::{Duration, Instant};
 
-use num_traits::{Bounded, ToPrimitive};
+#[cfg(feature = "metricator-compat")]
+pub mod num;
 
 /// Represents a monotonic absolute timestamp with millisecond resolution.
 ///
@@ -456,12 +457,11 @@ impl DivAssign<u64> for MillisDuration {
     }
 }
 
-
 impl Div<MillisDuration> for MillisDuration {
     type Output = MillisDuration;
 
     fn div(self, rhs: MillisDuration) -> Self::Output {
-        self/rhs.0
+        self / rhs.0
     }
 }
 
@@ -471,30 +471,6 @@ impl DivAssign<MillisDuration> for MillisDuration {
         *self = *self / rhs;
     }
 }
-
-impl Bounded for MillisDuration {
-    fn min_value() -> Self {
-        MillisDuration(0)
-    }
-
-    fn max_value() -> Self {
-        MillisDuration(u64::MAX)
-    }
-}
-
-impl ToPrimitive for MillisDuration {
-    fn to_i64(&self) -> Option<i64> {
-        match i64::try_from(self.0) {
-            Ok(x) => Some(x),
-            Err(_) => None,
-        }
-    }
-
-    fn to_u64(&self) -> Option<u64> {
-        Some(self.0)
-    }
-}
-
 
 /// Implements subtraction between two `Millis` instances, returning a `MillisDuration`.
 ///
@@ -519,8 +495,7 @@ impl Sub for Millis {
             MillisDuration::from_millis(self.0 - other.0)
         } else {
             panic!(
-                "Attempted to subtract a later Millis from an earlier one: {:?} - {:?}",
-                self, other
+                "Attempted to subtract a later Millis from an earlier one: {self:?} - {other:?}"
             );
         }
     }
@@ -539,7 +514,6 @@ impl From<Millis> for u64 {
         millis.0
     }
 }
-
 
 impl fmt::Display for Millis {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/num.rs
+++ b/src/num.rs
@@ -1,0 +1,24 @@
+use num_traits::{Bounded, ToPrimitive};
+
+impl Bounded for MillisDuration {
+    fn min_value() -> Self {
+        MillisDuration(0)
+    }
+
+    fn max_value() -> Self {
+        MillisDuration(u64::MAX)
+    }
+}
+
+impl ToPrimitive for MillisDuration {
+    fn to_i64(&self) -> Option<i64> {
+        match i64::try_from(self.0) {
+            Ok(x) => Some(x),
+            Err(_) => None,
+        }
+    }
+
+    fn to_u64(&self) -> Option<u64> {
+        Some(self.0)
+    }
+}

--- a/src/num.rs
+++ b/src/num.rs
@@ -1,5 +1,5 @@
-use num_traits::{Bounded, ToPrimitive};
-
+pub use num_traits::{Bounded, ToPrimitive};
+use crate::MillisDuration;
 impl Bounded for MillisDuration {
     fn min_value() -> Self {
         MillisDuration(0)

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -117,7 +117,7 @@ fn diff_duration() {
 fn div_duration() {
     let duration_greater = MillisDuration::from_millis(3000);
 
-    let diff = duration_greater / 30;
+    let diff = duration_greater / 30_u32;
 
     assert_eq!(diff, MillisDuration::from_millis(100));
 }


### PR DESCRIPTION
the main motivation for this is for calculating round trip time, hence using MillisDuration. 

it introduces a new dependency `num_traits` which I can feature gate if you prefer.